### PR TITLE
Add support for collect_instance_metadata and collect_security_groups configuration options

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -42,6 +42,12 @@ default['datadog']['create_dd_check_tags'] = nil
 # Collect EC2 tags, set to 'yes' to collect
 default['datadog']['collect_ec2_tags'] = nil
 
+# Collect instance metadata, set to 'yes' to collect
+default['datadog']['collect_instance_metadata'] = nil
+
+# Incorporate security-groups into tags collected from AWS EC2, set to 'yes' to collect
+default['datadog']['collect_security_groups'] = nil
+
 # Autorestart agent
 default['datadog']['autorestart'] = false
 

--- a/templates/default/datadog.conf.erb
+++ b/templates/default/datadog.conf.erb
@@ -22,6 +22,12 @@ create_dd_check_tags: <%= node['datadog']['create_dd_check_tags'] %>
 <% if node['datadog']['collect_ec2_tags'] -%>
 collect_ec2_tags: <%= node['datadog']['collect_ec2_tags'] %>
 <% end -%>
+<% if node['datadog']['collect_instance_metadata'] -%>
+collect_instance_metadata: <%= node['datadog']['collect_instance_metadata'] %>
+<% end -%>
+<% if node['datadog']['collect_security_groups'] -%>
+collect_security_groups: <%= node['datadog']['collect_security_groups'] %>
+<% end -%>
 
 <% if node['datadog']['web_proxy']['host'] -%>
 proxy_host: <%= node['datadog']['web_proxy']['host'] %>


### PR DESCRIPTION
This adds support for the collect_instance_metadata and collect_security_groups configuration options supported by datadog.conf. See https://github.com/DataDog/dd-agent/blob/master/datadog.conf.example for more information.
